### PR TITLE
Add demo-website to Backstage Software Catalog

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,8 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: demo-website
+spec:
+  type: website
+  lifecycle: experimental
+  owner: spotify-portal-demo/sharks

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -4,5 +4,5 @@ metadata:
   name: demo-website
 spec:
   type: website
-  lifecycle: experimental
+  lifecycle: production
   owner: spotify-portal-demo/sharks


### PR DESCRIPTION

## TL;DR

This pull request registers demo-website, as a component in our Backstage Software Catalog. 
It lists our team, spotify-portal-demo/sharks, as the owners of this component.
After this file has merged, you can view this component in Backstage Software Catalog here: → http://localhost:3000/catalog

## What is Backstage?

[Backstage](https://backstage.io/) is an open platform for building developer portals. Powered by a centralized 
software catalog, Backstage restores order to your microservices and infrastructure and enables your product teams 
to ship high-quality code quickly without compromising autonomy.

Backstage unifies all your infrastructure tooling, services, and documentation to create a streamlined development environment from end to end.

[![What is Backstage? (Explainer Video)](https://img.youtube.com/vi/85TQEpNCaU0/hqdefault.jpg)](https://youtu.be/85TQEpNCaU0)
